### PR TITLE
Update api-reference.md (#162)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -264,8 +264,8 @@ This function works similarly to `FOCUS()`, except instead of marking a block as
 
 ### describeFOCUS and describeSKIP
 ```
-describeFOCUS(phrase: string)
-describeSKIP(phrase: string)
+describeFOCUS(phrase: string, callback(context: table))
+describeSKIP(phrase: string, callback(context: table))
 ```
 
 These methods are special versions of `describe` that automatically mark the `describe` block as *focused* or *skipped*.


### PR DESCRIPTION
describeFOCUS and describeSKIP were incorrectly documented and stated to only have one parameter, this has been fixed to correctly reflect the source code.